### PR TITLE
Fix unpack value in utils/sh example

### DIFF
--- a/content/en/docs/Concepts/Packages/_index.md
+++ b/content/en/docs/Concepts/Packages/_index.md
@@ -98,7 +98,7 @@ requires:
 - name: "alpine"
   version: "3.1"
   category: "seed"
-unpack: "true" # Tells luet to use the image content by unpacking it
+unpack: true # Tells luet to use the image content by unpacking it
 includes: 
 - /bin/sh
 ```


### PR DESCRIPTION
Fix the error when building utils/sh package example in https://luet-lab.github.io/docs/docs/concepts/packages/#package-types

```
 Error: yaml: unmarshal errors:
  line 6: cannot unmarshal !!str `true` into bool
```